### PR TITLE
User management: implement DELETE /users/:id endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,19 @@ permissions need to be added to the API and given to the admin role:
 - `read:events`
 - `update:events`
 - `delete:events`
-- `read:roles`
-- `read:role_members`
 
 Make sure to enable RBAC in the settings for the API, and to toggle 'Add
 Permissions in the Access Token' on. The backend API needs to have access the
 Auth0 management API to manage user data. Be sure to give it that authorization
 in the Auth0 dashboard, and give it permissions to read, update, delete, and
-create users.
+create users, as well as permissions to read roles and role members:
+
+- `read:users`
+- `update:users`
+- `delete:users`
+- `create:users`
+- `read:roles`
+- `read:role_members`
 
 ## 1. Create a .env file
 In ./server, create a .env file that will allow NodeJS to read environment variables, add these variables.

--- a/server/src/middlewares/errorHandler.js
+++ b/server/src/middlewares/errorHandler.js
@@ -4,7 +4,23 @@ const {
     InsufficientScopeError,
 } = require("express-oauth2-jwt-bearer");
 
+if (process.env.NODE_ENV !== "production") {
+    const dotenv = require("dotenv");
+    dotenv.config()
+}
+
+const winston = require("winston");
+const { combine, timestamp, json, errors } = winston.format;
+const logger = winston.createLogger({
+  level: "info",
+  format: combine(errors({ stack: process.env.NODE_ENV !== 'production' }),
+      timestamp(), json()),  
+  transports: [new winston.transports.Console()],
+});
+
 const errorHandler = (err, req, res, next) => {
+    logger.error(err);
+
     if (err instanceof InsufficientScopeError) {
         const message = "Permission denied";
         res.status(err.status).json({ message });

--- a/server/src/models/users.js
+++ b/server/src/models/users.js
@@ -9,6 +9,7 @@ const userSchema = new mongoose.Schema({
       type: String,
       required: true,
       unique: true,
+      immutable: true,
   },
   firstName: {
     type: String,
@@ -39,14 +40,17 @@ const userSchema = new mongoose.Schema({
   // in inches
   height: {
     type: Number,
+    min: 1,
   },
   age: {
-    type: Number
+    type: Number,
+    min: 1,
   },
   horseExperience: {
     type: Number,
     required: true,
-    default: 0
+    default: 0,
+    min: 0,
   },
   horseRiding: {
     type: Boolean

--- a/server/src/models/users.js
+++ b/server/src/models/users.js
@@ -1,6 +1,17 @@
 const { ObjectId } = require('mongodb');
 const mongoose = require('mongoose');
 
+if (process.env.NODE_ENV !== "production") {
+    const dotenv = require("dotenv")
+    dotenv.config()
+}
+
+const auth0ApiUrl = `https://${process.env.AUTH0_DOMAIN}/api/v2`
+const auth0usersEndpoint = `${auth0ApiUrl}/users`;
+const auth0adminUsersEndpoint = `${auth0ApiUrl}/roles/${process.env.AUTH0_ADMIN_ROLE_ID}/users`;
+
+const { httpClient } = require('../utils/httpClient')
+
 const userSchema = new mongoose.Schema({
   // The auth0 id associated with a user. 
   // This is different from the _id ObjectID
@@ -64,6 +75,16 @@ const userSchema = new mongoose.Schema({
   horseLeading: {
     type: Boolean
   }
+});
+
+userSchema.pre('deleteOne', {document: true, query: false}, async function(next) {
+    console.log("hello")
+    try {
+        await httpClient.delete(auth0usersEndpoint + '/' + this.user_id)
+    } catch(err) {
+        throw err
+    }
+    next()
 });
 
 const User = mongoose.model('User', userSchema);

--- a/server/src/utils/httpClient.js
+++ b/server/src/utils/httpClient.js
@@ -1,6 +1,9 @@
 const axios = require('axios');
-const dotenv = require("dotenv")
-dotenv.config()
+
+if (process.env.NODE_ENV !== "production") {
+    const dotenv = require("dotenv")
+    dotenv.config()
+}
 
 const httpClient = axios.create();
 

--- a/server/test/mocks/Auth0handlers.ts
+++ b/server/test/mocks/Auth0handlers.ts
@@ -15,7 +15,7 @@ interface userMap {
   [key: string]: Auth0User
 }
 
-var userStore: userMap = {}
+export var userStore: userMap = {}
 
 const ApiUrl = `https://${process.env.AUTH0_DOMAIN}/api/v2`
 const usersEndpoint = `${ApiUrl}/users`;
@@ -24,6 +24,8 @@ const adminUsersEndpoint = `${ApiUrl}/roles/${process.env.AUTH0_ADMIN_ROLE_ID}/u
 export const handlers = [
   rest.get(usersEndpoint, mockGetUsers),
   rest.post(usersEndpoint, mockPostUsers),
+  rest.put(usersEndpoint + '/:user_id', mockUpdateUser),
+  rest.delete(usersEndpoint + '/:user_id', mockDeleteUser),
   rest.get(adminUsersEndpoint, mockGetAdmins),
   rest.post(adminUsersEndpoint, mockSetAdmin),
 ]
@@ -52,6 +54,44 @@ function mockGetUsers(req, res, ctx) {
   )
 }
 
+function mockUpdateUser(req, res, ctx) {
+  const { user_id } = req.params;
+  if (!(user_id in userStore)) {
+    return res(
+      ctx.status(404),
+      ctx.json({
+          "statusCode": 404,
+          "error": "Not Found",
+          "message": "The user does not exist.",
+          "errorCode": "inexistent_user"
+      })
+    )
+  }
+
+  // email is the only thing about the Auth0 user entity
+  // that we ever need to modify for our usecase so this
+  // is the only thing we mock out
+  userStore[user_id].email = req.body.email
+  return res(
+    ctx.status(200),
+    ctx.json(userStore[user_id]),
+  )
+}
+
+function mockDeleteUser(req, res, ctx) {
+  const { user_id } = req.params;
+
+  // as long as the user_id has the right format, the real
+  // Auth0 API doesn't actually care if the user to be deleted
+  // exists or not
+  delete userStore[user_id]
+  return res(
+    ctx.set('cache-control', 'no-cache'),
+    ctx.set('content-type', 'application/json; charset=utf-8'),
+    ctx.status(204),
+  )
+}
+
 function mockGetAdmins(req, res, ctx) {
   const adminUsers = Object.values(userStore).filter(user => user.isAdmin)
   return res(
@@ -61,8 +101,8 @@ function mockGetAdmins(req, res, ctx) {
 }
 
 function mockSetAdmin(req, res, ctx) {
-  const { user_id } = req.params
-  userStore[user_id].isAdmin = true
+  const user_ids = req.params
+  user_ids.forEach(user_id => {userStore[user_id].isAdmin = true})
   return res(
     ctx.status(200),
     ctx.json({message:"success"})

--- a/server/test/mocks/Auth0handlers.ts
+++ b/server/test/mocks/Auth0handlers.ts
@@ -17,9 +17,13 @@ interface userMap {
 
 export var userStore: userMap = {}
 
-const ApiUrl = `https://${process.env.AUTH0_DOMAIN}/api/v2`
-const usersEndpoint = `${ApiUrl}/users`;
-const adminUsersEndpoint = `${ApiUrl}/roles/${process.env.AUTH0_ADMIN_ROLE_ID}/users`;
+export function resetUserStore() {
+  userStore = {}
+}
+
+export const ApiUrl = `https://${process.env.AUTH0_DOMAIN}/api/v2`
+export const usersEndpoint = `${ApiUrl}/users`;
+export const adminUsersEndpoint = `${ApiUrl}/roles/${process.env.AUTH0_ADMIN_ROLE_ID}/users`;
 
 export const handlers = [
   rest.get(usersEndpoint, mockGetUsers),


### PR DESCRIPTION
This pull request completes the implementation of the DELETE /users/:id endpoint to ensure that deleting a user in the application DB coincides triggers deletion of the corresponding Auth0 user entity. If deletion of the Auth0 user entity fails, the application aborts the operation, so that deletion operations in the two databases will coincide atomically as long as the deletion is initiated through the application API.

It includes some documentation of some more permissions configurations that need to be made for the application to be able to access the Auth0 management API properly. This is something that actually should have been added in the last recent PR. It also includes some changes to make the /user route's error handling more idiomatic, and some error logging functionality.