### PR TITLE
User management: backend functionality assigning roles to users

### DIFF
--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -69,6 +69,19 @@ module.exports.updateUserById = asyncHandler(async function(req, res, next) {
     }
 
     try {
+        if ("setAdmin" in req.body) {
+            if (req.body.setAdmin === true) {
+                await httpClient.post(
+                `${auth0usersEndpoint}/${user.user_id}/roles`,
+                {roles: [process.env.AUTH0_ADMIN_ROLE_ID]})
+            } else {
+                // the 2nd parameter to axios.delete is axios options, not
+                // a request body like in axios.post or axios.put
+                await httpClient.delete(
+                `${auth0usersEndpoint}/${user.user_id}/roles`,
+                    { data: {roles: [process.env.AUTH0_ADMIN_ROLE_ID]} })
+            }
+        }
         user.set(req.body);
         if (user.modifiedPaths().includes("email")) {
             await httpClient.patch(

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -60,16 +60,32 @@ module.exports.createUser = asyncHandler(async function(req, res, next) {
   }
 });
 
-module.exports.updateUserById = asyncHandler(async function(req, res) {
-    const id = await User.findById(req.params.id)
-    if (!id)
-    {
+module.exports.updateUserById = asyncHandler(async function(req, res, next) {
+    const user = await User.findById(req.params.id)
+    if (!user) {
       res.status(400).json({
         error: "User not found"
       });
     }
-    const response = await User.findByIdAndUpdate(req.params.id, req.body, {new: true});
-    res.status(200).json(response);
+
+    try {
+        user.set(req.body);
+        if (user.modifiedPaths().includes("email")) {
+            await httpClient.patch(
+                `${auth0usersEndpoint}/${user.user_id}`,
+                { email: user.email }
+            )
+        }
+        await user.save();
+        res.status(200).json(user);
+
+    } catch(err) {
+
+      if (err instanceof mongoose.Error.ValidationError) {
+          res.status(400).json(err.errors);
+      }
+      next(err)
+    }
 });
 
 module.exports.deleteUserById = asyncHandler(async function(req, res, next) {

--- a/server/src/models/users.js
+++ b/server/src/models/users.js
@@ -78,7 +78,6 @@ const userSchema = new mongoose.Schema({
 });
 
 userSchema.pre('deleteOne', {document: true, query: false}, async function(next) {
-    console.log("hello")
     try {
         await httpClient.delete(auth0usersEndpoint + '/' + this.user_id)
     } catch(err) {

--- a/server/test/mocks/Auth0handlers.ts
+++ b/server/test/mocks/Auth0handlers.ts
@@ -28,7 +28,7 @@ export const adminUsersEndpoint = `${ApiUrl}/roles/${process.env.AUTH0_ADMIN_ROL
 export const handlers = [
   rest.get(usersEndpoint, mockGetUsers),
   rest.post(usersEndpoint, mockPostUsers),
-  rest.put(usersEndpoint + '/:user_id', mockUpdateUser),
+  rest.patch(usersEndpoint + '/:user_id', mockUpdateUser),
   rest.delete(usersEndpoint + '/:user_id', mockDeleteUser),
   rest.get(adminUsersEndpoint, mockGetAdmins),
   rest.post(adminUsersEndpoint, mockSetAdmin),

--- a/server/test/mocks/Auth0handlers.ts
+++ b/server/test/mocks/Auth0handlers.ts
@@ -30,8 +30,9 @@ export const handlers = [
   rest.post(usersEndpoint, mockPostUsers),
   rest.patch(usersEndpoint + '/:user_id', mockUpdateUser),
   rest.delete(usersEndpoint + '/:user_id', mockDeleteUser),
+  rest.post(usersEndpoint + '/:user_id/roles', mockSetAdmin),
+  rest.delete(usersEndpoint + '/:user_id/roles', mockUnSetAdmin),
   rest.get(adminUsersEndpoint, mockGetAdmins),
-  rest.post(adminUsersEndpoint, mockSetAdmin),
 ]
 
 async function mockPostUsers(req, res, ctx) {
@@ -105,10 +106,32 @@ function mockGetAdmins(req, res, ctx) {
 }
 
 function mockSetAdmin(req, res, ctx) {
-  const user_ids = req.params
-  user_ids.forEach(user_id => {userStore[user_id].isAdmin = true})
+  const user_id = req.params.user_id
+  if (!req.body?.roles?.includes(process.env.AUTH0_ADMIN_ROLE_ID)) {
+    return res(
+      ctx.status(400),
+      ctx.json({message: "Invalid  request"})
+    )
+  }
+  userStore[user_id].isAdmin = true
   return res(
-    ctx.status(200),
-    ctx.json({message:"success"})
+    ctx.status(204),
+  )
+}
+
+function mockUnSetAdmin(req, res, ctx) {
+  const user_id = req.params.user_id
+  console.log("trying to unset admin role for: ", user_id)
+  if (!req.body?.roles?.includes(process.env.AUTH0_ADMIN_ROLE_ID)) {
+    console.log("there was a problem with the request format")
+    console.log(req)
+    return res(
+      ctx.status(400),
+      ctx.json({message: "Invalid  request"})
+    )
+  }
+  userStore[user_id].isAdmin = false
+  return res(
+    ctx.status(204),
   )
 }

--- a/server/test/unit/user.test.js
+++ b/server/test/unit/user.test.js
@@ -315,7 +315,7 @@ describe("PATCH /user/:id", () => {
         expect(res.body[0].horseLeading).toEqual(true)
     })
 
-    it("modifying a user's email changes the users auth0 email", async () => {
+    it("modifying a user's email or role changes the user's auth0 email or role", async () => {
         await request(app)
             .post('/users')
             .send(validUser)
@@ -341,6 +341,18 @@ describe("PATCH /user/:id", () => {
         expect(res.body.firstName).toEqual("foo")
         expect(res.body.age).toEqual(20)
         expect(res.body.horseLeading).toEqual(true)
+
+        res = await request(app)
+            .patch('/users/' + id)
+            .send({ setAdmin: true })
+            .set('Accept', 'application/json')
+        expect(userStore[user_id].isAdmin).toEqual(true)
+
+        res = await request(app)
+            .patch('/users/' + id)
+            .send({ setAdmin: false })
+            .set('Accept', 'application/json')
+        expect(userStore[user_id].isAdmin).toEqual(false)
 
         res = await request(app)
             .get('/users')


### PR DESCRIPTION
This PR adds functionality to the server for modifying users and assigning them to roles. I haven't yet been able to manually test these changes with the actual Auth0 management API. I'm planning to do so in further work once the admin UI is built out a bit more to be able to communicate with the PATCH /users/:id endpoint.