### PR TITLE
User management: edit and delete users through the admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ following steps. You will also need to make an Auth0 API with the identifier
 authorization parameter when requesting access tokens for the API. The following
 permissions need to be added to the API and given to the admin role:
 
+- `create:users`
+- `update:users`
+- `delete:users`
 - `create:events`
 - `read:events`
 - `update:events`

--- a/client/src/components/AdminUI/AdminUI.js
+++ b/client/src/components/AdminUI/AdminUI.js
@@ -132,7 +132,7 @@ function AdminUI() {
     }
 
     return isAuthenticated && isAdmin && (
-          <Container sx={{ marginTop: 4, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <Container maxWidth='false' sx={{ width: '100%', overflowX: 'auto', marginTop: 4, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             <DataGrid
                 getRowId={(user) => user.user_id}
                 rows={rows}

--- a/client/src/components/AdminUI/AdminUI.js
+++ b/client/src/components/AdminUI/AdminUI.js
@@ -38,6 +38,13 @@ function AdminUI() {
           editable: true,
         },
         {
+            field: 'userType',
+            headerName: 'user type',
+            editable: true,
+            type: 'singleSelect',
+            valueOptions: ['volunteer', 'instructor', 'volunteer coordinator']
+        },
+        {
           field: 'isAdmin',
           headerName: 'Admin',
           editable: true,

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -69,8 +69,8 @@ module.exports.updateUserById = asyncHandler(async function(req, res, next) {
     }
 
     try {
-        if ("setAdmin" in req.body) {
-            if (req.body.setAdmin === true) {
+        if ("isAdmin" in req.body) {
+            if (req.body.isAdmin === true) {
                 await httpClient.post(
                 `${auth0usersEndpoint}/${user.user_id}/roles`,
                 {roles: [process.env.AUTH0_ADMIN_ROLE_ID]})
@@ -102,16 +102,20 @@ module.exports.updateUserById = asyncHandler(async function(req, res, next) {
 });
 
 module.exports.deleteUserById = asyncHandler(async function(req, res, next) {
-  const user = await User.findById(req.params.id);
-
-  if (!user)
-  {
-      res.status(400).json({
-          error: "no user with specified id"
-      });
+  try {
+      console.log(req.params.id)
+      const user = await User.findById(req.params.id);
+      if (!user)
+      {
+          res.status(400).json({
+              error: "no user with specified id"
+          });
+      }
+      await user.deleteOne();
+      res.status(200).json({ message: `deleted user ${req.params.id}` });
+  } catch(err) {
+      res.status(500)
+      next(err)
   }
-
-  await user.deleteOne();
-  res.status(200).json({ message: `deleted user ${req.params.id}` });
 });
 

--- a/server/test/unit/user.test.js
+++ b/server/test/unit/user.test.js
@@ -344,13 +344,13 @@ describe("PATCH /user/:id", () => {
 
         res = await request(app)
             .patch('/users/' + id)
-            .send({ setAdmin: true })
+            .send({ isAdmin: true })
             .set('Accept', 'application/json')
         expect(userStore[user_id].isAdmin).toEqual(true)
 
         res = await request(app)
             .patch('/users/' + id)
-            .send({ setAdmin: false })
+            .send({ isAdmin: false })
             .set('Accept', 'application/json')
         expect(userStore[user_id].isAdmin).toEqual(false)
 


### PR DESCRIPTION
This PR updates the front-end admin UI to be able to make use of the backend's PATCH and DELETE /users/:id endpoints. I can confirm it works as expected through manual testing, although I'm not sure whether the React code in this PR uses idiomatic patterns.